### PR TITLE
Remove unused station test comment

### DIFF
--- a/backend/src/tests/station.test.ts
+++ b/backend/src/tests/station.test.ts
@@ -131,6 +131,3 @@ describe('Station API', () => {
     });
   });
 });
-// Remove these function stubs; they are not needed when using a proper test runner
-
-


### PR DESCRIPTION
## Summary
- clean up `station.test.ts` by removing comment about function stubs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a15ed13c8320a6ca6f3bc010bfa1