### PR TITLE
Add deleted station check in integration test

### DIFF
--- a/backend/src/tests/station.test.ts
+++ b/backend/src/tests/station.test.ts
@@ -125,9 +125,16 @@ describe('Station API', () => {
       const listRes = await request(app)
         .get('/api/stations')
         .set('Authorization', `Bearer ${authToken}`);
-      
+
       const deletedStation = listRes.body.find((s: any) => s.id === stationId);
       expect(deletedStation).toBeUndefined();
+
+      // Verify the station cannot be retrieved directly
+      const getRes = await request(app)
+        .get(`/api/stations/${stationId}`)
+        .set('Authorization', `Bearer ${authToken}`);
+
+      expect(getRes.status).toBe(404);
     });
   });
 });


### PR DESCRIPTION
## Summary
- update soft delete test to verify station GET returns 404

## Testing
- `npm test` *(fails: Module 'server' has no default export)*

------
https://chatgpt.com/codex/tasks/task_e_6853a23a0c1483208fa7b69320639eb8