### PR TITLE
Use local env vars for setup

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -12,15 +12,15 @@ CREATE DATABASE fuelsync;
 
 ### 2. Configure Environment Variables
 
-Copy the `.env.example` file to `.env` and update the database connection parameters:
+Set your PostgreSQL credentials as environment variables. Example:
 
 ```
-DB_HOST=fuelsync-server.postgres.database.azure.com
-DB_PORT=5432
-DB_NAME=fuelsync_db1
-DB_USER=fueladmin
-DB_PASSWORD=your_password
-DB_SSL=true
+export DB_HOST=localhost
+export DB_PORT=5432
+export DB_NAME=fuelsync_db1
+export DB_USER=postgres
+export DB_PASSWORD=postgres
+export DB_SSL=false
 ```
 
 ### 3. Check Database Connection

--- a/README.md
+++ b/README.md
@@ -27,8 +27,13 @@ npm run setup
 
 # 2. Configure database
 cd backend
-cp .env.example .env
-# Edit .env with your PostgreSQL credentials
+# Set your PostgreSQL credentials as environment variables
+export DB_HOST=localhost
+export DB_PORT=5432
+export DB_NAME=test_fuelsync
+export DB_USER=postgres
+export DB_PASSWORD=postgres
+export DB_SSL=false
 
 # 3. Setup database
 npm run db:setup

--- a/TESTING_GUIDE.md
+++ b/TESTING_GUIDE.md
@@ -22,7 +22,12 @@ This guide provides step-by-step instructions for testing the FuelSync Hub platf
    ```
 3. Set up environment variables:
    ```bash
-   cp .env.example .env
+   export DB_HOST=localhost
+   export DB_PORT=5432
+   export DB_NAME=test_fuelsync
+   export DB_USER=postgres
+   export DB_PASSWORD=postgres
+   export DB_SSL=false
    ```
 4. Run database migrations and seed data:
    ```bash
@@ -411,7 +416,7 @@ This script will attempt to log in with each user type and display the results.
 **Solution**:
 1. Check the actual database schema:
    ```bash
-   ts-node -e "import { Pool } from 'pg'; import dotenv from 'dotenv'; import path from 'path'; dotenv.config({ path: path.resolve(__dirname, '.env') }); const pool = new Pool({ host: process.env.DB_HOST, port: parseInt(process.env.DB_PORT || '5432'), user: process.env.DB_USER, password: process.env.DB_PASSWORD, database: process.env.DB_NAME, ssl: { rejectUnauthorized: false } }); async function checkSchema() { try { const client = await pool.connect(); try { const result = await client.query('SELECT column_name FROM information_schema.columns WHERE table_name = \'TABLE_NAME\' ORDER BY ordinal_position'); console.log('TABLE_NAME columns:'); result.rows.forEach(row => console.log(row.column_name)); } finally { client.release(); } await pool.end(); } catch (err) { console.error('Error:', err); } } checkSchema();"
+   ts-node -e "import { Pool } from 'pg'; const pool = new Pool({ host: process.env.DB_HOST, port: parseInt(process.env.DB_PORT || '5432'), user: process.env.DB_USER, password: process.env.DB_PASSWORD, database: process.env.DB_NAME, ssl: { rejectUnauthorized: false } }); async function checkSchema() { try { const client = await pool.connect(); try { const result = await client.query('SELECT column_name FROM information_schema.columns WHERE table_name = \'TABLE_NAME\' ORDER BY ordinal_position'); console.log('TABLE_NAME columns:'); result.rows.forEach(row => console.log(row.column_name)); } finally { client.release(); } await pool.end(); } catch (err) { console.error('Error:', err); } } checkSchema();"
    ```
    Replace `TABLE_NAME` with the name of the table you want to check.
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -8,7 +8,7 @@ This error indicates that your PostgreSQL server is rejecting the connection fro
 
 **Solution:**
 
-1. **Check your .env file**:
+1. **Check your environment variables**:
    Make sure your database connection parameters are correct:
    ```
    DB_HOST=fuelsync-server.postgres.database.azure.com

--- a/backend/src/config/database.ts
+++ b/backend/src/config/database.ts
@@ -1,13 +1,6 @@
 // src/config/database.ts
 import { Pool } from 'pg';
-import path from 'path';
-import dotenv from 'dotenv';
-const skipEnvLoad = process.env.CI === 'true' || process.env.CODEX_MODE === 'true' || process.env.HEADLESS === 'true';
-
-if (!skipEnvLoad) {
-  console.log('Env load skipped!!!')
-  dotenv.config({ path: path.resolve(__dirname, '../../.env') });
-}
+// Environment variables should be provided by the runtime
 
 
 // Log connection parameters (without password)

--- a/backend/src/config/environment.ts
+++ b/backend/src/config/environment.ts
@@ -1,7 +1,4 @@
-import dotenv from 'dotenv';
-import path from 'path';
-
-dotenv.config({ path: path.resolve(__dirname, '../../.env') });
+// Environment variables are expected to be provided by the runtime
 
 interface Config {
   nodeEnv: string;

--- a/setup.sh
+++ b/setup.sh
@@ -40,44 +40,22 @@ print_success "Dependencies installed"
 if [ -d "backend" ]; then
     print_status "Setting up backend..."
     cd backend || exit 1
-    # Environment: Codex/Test-safe setup
-    if [ "$CI" = "true" ] || [ "$CODEX_MODE" = "true" ]; then
-    print_status "Using in-memory/test database configuration (CI or Codex mode)"
-    export DB_HOST=localhost
-    export DB_PORT=5432
-    export DB_NAME=test_fuelsync
-    export DB_USER=postgres
-    export DB_PASSWORD=postgres
-    export DB_SSL=false
-    else
-    # Local dev fallback
-    if [ ! -f ".env" ]; then
-        if [ -f ".env.example" ]; then
-        print_warning ".env not found → creating from example"
-        cp .env.example .env
 
-        # 👇 This should be skipped in headless mode
-        if [ -t 0 ]; then
-            print_warning "Please update .env with your DB credentials"
-            read -p "Press Enter after updating .env to continue..."
-        else
-            print_warning "Headless mode detected — skipping .env prompt"
-        fi
-        else
-        print_error "Missing .env and .env.example. Aborting setup."
-        exit 1
-        fi
-    else
-        print_success ".env file found"
-    fi
-    fi
+    # Always use local database settings
+    print_status "Configuring local database connection"
+    export DB_HOST=${DB_HOST:-localhost}
+    export DB_PORT=${DB_PORT:-5432}
+    export DB_NAME=${DB_NAME:-test_fuelsync}
+    export DB_USER=${DB_USER:-postgres}
+    export DB_PASSWORD=${DB_PASSWORD:-postgres}
+    export DB_SSL=${DB_SSL:-false}
 
     # Test database connection
     print_status "Testing database connection..."
     if npm run db:check; then
         print_success "Database connection successful"
     else
-        print_error "Database connection failed. Please check your .env configuration."
+        print_error "Database connection failed. Please check your database configuration."
         exit 1
     fi
     


### PR DESCRIPTION
## Summary
- stop referencing `.env` in backend config
- always export default database settings in setup script
- document environment variables for database configuration
- update testing and troubleshooting docs to avoid `.env`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543d338b80832099c3a60c5504e673