### PR TITLE
Add UP/DOWN markers to SQL migrations

### DIFF
--- a/backend/db/migrations/000_schema.sql
+++ b/backend/db/migrations/000_schema.sql
@@ -1,5 +1,4 @@
-BEGIN;
-
+-- UP
 -- Drop schema and recreate fresh
 DROP SCHEMA IF EXISTS public CASCADE;
 CREATE SCHEMA public;
@@ -184,4 +183,6 @@ CREATE INDEX idx_sales_recorded_at ON sales(recorded_at);
 CREATE INDEX idx_sales_status ON sales(status);
 CREATE INDEX idx_sales_payment_method ON sales(payment_method);
 
-COMMIT;
+
+-- DOWN
+DROP SCHEMA IF EXISTS public CASCADE;

--- a/backend/db/migrations/20230615_add_creditor_payment_methods.sql
+++ b/backend/db/migrations/20230615_add_creditor_payment_methods.sql
@@ -1,3 +1,4 @@
+-- UP
 -- Add new payment methods to the payment_method type if it doesn't already include them
 DO $$
 BEGIN
@@ -44,3 +45,8 @@ CREATE TABLE IF NOT EXISTS creditor_payments (
 
 -- Create index on creditor_id for faster lookups
 CREATE INDEX IF NOT EXISTS idx_creditor_payments_creditor_id ON creditor_payments(creditor_id);
+-- DOWN
+DROP INDEX IF EXISTS idx_creditor_payments_creditor_id;
+DROP TABLE IF EXISTS creditor_payments;
+DROP TYPE IF EXISTS creditor_payment_method;
+

--- a/backend/db/migrations/20230616_add_tender_entries.sql
+++ b/backend/db/migrations/20230616_add_tender_entries.sql
@@ -1,3 +1,4 @@
+-- UP
 -- Create tender_type enum if it doesn't exist
 DO $$
 BEGIN
@@ -53,3 +54,16 @@ CREATE INDEX IF NOT EXISTS idx_tender_entries_shift_id ON tender_entries(shift_i
 CREATE INDEX IF NOT EXISTS idx_tender_entries_station_id ON tender_entries(station_id);
 CREATE INDEX IF NOT EXISTS idx_tender_entries_user_id ON tender_entries(user_id);
 CREATE INDEX IF NOT EXISTS idx_tender_entries_tender_type ON tender_entries(tender_type);
+-- DOWN
+DROP INDEX IF EXISTS idx_tender_entries_tender_type;
+DROP INDEX IF EXISTS idx_tender_entries_user_id;
+DROP INDEX IF EXISTS idx_tender_entries_station_id;
+DROP INDEX IF EXISTS idx_tender_entries_shift_id;
+DROP INDEX IF EXISTS idx_shifts_status;
+DROP INDEX IF EXISTS idx_shifts_user_id;
+DROP INDEX IF EXISTS idx_shifts_station_id;
+DROP TABLE IF EXISTS tender_entries;
+DROP TABLE IF EXISTS shifts;
+DROP TYPE IF EXISTS shift_status;
+DROP TYPE IF EXISTS tender_type;
+

--- a/backend/db/migrations/20230617_add_fuel_price_history.sql
+++ b/backend/db/migrations/20230617_add_fuel_price_history.sql
@@ -1,3 +1,4 @@
+-- UP
 -- Create fuel_price_history table if it doesn't exist
 CREATE TABLE IF NOT EXISTS fuel_price_history (
     id UUID PRIMARY KEY,
@@ -40,3 +41,12 @@ CREATE TRIGGER set_fuel_price_effective_to
 AFTER INSERT ON fuel_price_history
 FOR EACH ROW
 EXECUTE FUNCTION update_fuel_price_effective_to();
+-- DOWN
+DROP TRIGGER IF EXISTS set_fuel_price_effective_to ON fuel_price_history;
+DROP FUNCTION IF EXISTS update_fuel_price_effective_to();
+DROP INDEX IF EXISTS idx_fuel_price_history_effective_range;
+DROP INDEX IF EXISTS idx_fuel_price_history_effective_from;
+DROP INDEX IF EXISTS idx_fuel_price_history_fuel_type;
+DROP INDEX IF EXISTS idx_fuel_price_history_station_id;
+DROP TABLE IF EXISTS fuel_price_history;
+

--- a/backend/db/migrations/20230618_fix_schema_issues.sql
+++ b/backend/db/migrations/20230618_fix_schema_issues.sql
@@ -1,3 +1,4 @@
+-- UP
 -- This migration fixes any schema issues and ensures all required tables exist
 
 -- Create station_user_role enum if it doesn't exist
@@ -164,3 +165,21 @@ CREATE TRIGGER set_fuel_price_effective_to
 AFTER INSERT ON fuel_price_history
 FOR EACH ROW
 EXECUTE FUNCTION update_fuel_price_effective_to();
+-- DOWN
+DROP TRIGGER IF EXISTS set_fuel_price_effective_to ON fuel_price_history;
+DROP FUNCTION IF EXISTS update_fuel_price_effective_to();
+DROP INDEX IF EXISTS idx_creditor_payments_creditor_id;
+DROP INDEX IF EXISTS idx_user_stations_active;
+DROP INDEX IF EXISTS idx_user_stations_station_id;
+DROP INDEX IF EXISTS idx_user_stations_user_id;
+DROP TABLE IF EXISTS fuel_price_history;
+DROP TABLE IF EXISTS tender_entries;
+DROP TABLE IF EXISTS shifts;
+DROP TABLE IF EXISTS creditor_payments;
+DROP TABLE IF EXISTS creditors;
+DROP TABLE IF EXISTS user_stations;
+DROP TYPE IF EXISTS creditor_payment_method;
+DROP TYPE IF EXISTS shift_status;
+DROP TYPE IF EXISTS tender_type;
+DROP TYPE IF EXISTS station_user_role;
+

--- a/backend/db/migrations/20230619_add_fuel_inventory_deliveries.sql
+++ b/backend/db/migrations/20230619_add_fuel_inventory_deliveries.sql
@@ -1,3 +1,4 @@
+-- UP
 -- Create fuel_inventory table if it doesn't exist
 CREATE TABLE IF NOT EXISTS fuel_inventory (
     id UUID PRIMARY KEY,
@@ -59,3 +60,13 @@ CREATE TABLE IF NOT EXISTS day_reconciliations (
 
 -- Index for day_reconciliations
 CREATE INDEX IF NOT EXISTS idx_day_reconciliations_station_id ON day_reconciliations(station_id);
+
+-- DOWN
+DROP INDEX IF EXISTS idx_day_reconciliations_station_id;
+DROP INDEX IF EXISTS idx_fuel_deliveries_received_by;
+DROP INDEX IF EXISTS idx_fuel_deliveries_station_id;
+DROP INDEX IF EXISTS idx_fuel_inventory_station_id;
+DROP TABLE IF EXISTS day_reconciliations;
+DROP TABLE IF EXISTS fuel_deliveries;
+DROP TABLE IF EXISTS fuel_inventory;
+


### PR DESCRIPTION
## Summary
- add migration markers for older SQL scripts
- include rollback statements

## Testing
- `npm run db:migrate` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685467a9aa448320a90b770f15610811