### PR TITLE
docs: replace planType with subscription_plan field

### DIFF
--- a/docs/CHANGELOG_AI.md
+++ b/docs/CHANGELOG_AI.md
@@ -17,7 +17,7 @@ You may now begin.
 - Documented inventory endpoints in API.md.
 - Updated seeding guide for 3 attendant users.
 - Added shifts and tender_entries to ERD and DATABASE_GUIDE.
-- Replaced planType references with subscription_plan in DATABASE_SCHEMA.md.
+- Replaced `planType` references with the `subscription_plan` field in DATABASE_SCHEMA.md.
 - Synced PLANS.md snippet with latest PLAN_CONFIG settings.
 - Seed script now includes station_id when creating creditors.
 

--- a/docs/examples/api-client.js
+++ b/docs/examples/api-client.js
@@ -61,10 +61,10 @@ const createFuelSyncClient = (baseUrl = 'http://localhost:3001/api') => {
       },
       
       // Register
-      register: async (name, email, password, planType) => {
+      register: async (name, email, password, subscription_plan) => {
         const response = await request('/auth/register', {
           method: 'POST',
-          body: JSON.stringify({ name, email, password, planType })
+          body: JSON.stringify({ name, email, password, subscription_plan })
         });
         
         return response.data;

--- a/docs/examples/curl-examples.md
+++ b/docs/examples/curl-examples.md
@@ -43,7 +43,7 @@ curl -X POST http://localhost:3001/api/auth/register \
     "name": "New Tenant",
     "email": "owner@example.com",
     "password": "password123",
-    "planType": "basic"
+    "subscription_plan": "basic"
   }'
 ```
 
@@ -56,7 +56,7 @@ Response:
     "tenant": {
       "id": "tenant-uuid",
       "name": "New Tenant",
-      "planType": "basic"
+      "subscription_plan": "basic"
     }
   }
 }


### PR DESCRIPTION
## Summary
- update docs examples to use `subscription_plan`
- clarify changelog wording for plan field change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685514550d9c832082437908439b3254