### PR TITLE
Remove unused API doc sections

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -66,14 +66,11 @@ This document outlines the available API endpoints grouped by user roles in the 
 ### ⛽ Operations
 
 * `POST /api/nozzles/:id/readings` — Submit cumulative reading
-* `GET /api/nozzles/:id/readings` — Get historical readings
 * `GET /api/stations/:stationId/nozzle-readings/previous` — Previous day's readings
 * `GET /api/stations/:stationId/fuel-prices` — Current prices for station nozzles
 * `POST /api/stations/:stationId/nozzle-readings` — Submit today's readings
-* `POST /api/sales/manual` — Add manual sale
 * `GET /api/sales?stationId=...` — Get sales list
 * `POST /api/fuel-prices` — Add/update fuel price
-* `POST /api/fuel-deliveries` — Log fuel stock delivery
 
 ### 💳 Credit
 
@@ -93,8 +90,6 @@ This document outlines the available API endpoints grouped by user roles in the 
 > Assigned to 1+ stations by owner
 
 * `POST /api/nozzles/:id/readings` — Enter readings
-* `POST /api/sales/manual` — Add manual sale
-* `POST /api/fuel-deliveries` — Record delivery
 * `GET /api/dashboard` — Manager-level dashboard
 * `GET /api/employees` — List attendants at station
 
@@ -105,7 +100,6 @@ This document outlines the available API endpoints grouped by user roles in the 
 > Limited to daily operation tasks only
 
 * `POST /api/nozzles/:id/readings` — Submit daily reading
-* `POST /api/sales/manual` — Add sale from reading
 
 ---
 ## 🧾 Tender & Shift Routes

--- a/docs/CHANGELOG_AI.md
+++ b/docs/CHANGELOG_AI.md
@@ -50,3 +50,7 @@ You may now begin.
 - Documented `sales.voided_by` and `sales.credit_party_id` relationships in DATABASE_GUIDE.
 - Added corresponding links to ERD diagram.
 - Documented all plan feature flags in PLANS.md to match `planConfig.ts`
+
+## 2025-06-26
+- Removed undocumented endpoints from API docs: `GET /api/nozzles/:id/readings`,
+  `POST /api/sales/manual`, and `POST /api/fuel-deliveries`.


### PR DESCRIPTION
## Summary
- prune legacy endpoints from API docs
- log the doc update in CHANGELOG_AI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68551c7a75d4832095535f26fc41a264