### PR TITLE
Document pump/nozzle plan limit guards

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -49,12 +49,12 @@ This document outlines the available API endpoints grouped by user roles in the 
 ### 🛠 Setup
 
 * `POST /api/stations` — Create a station
-* `POST /api/pumps` — Add a pump to a station
+* `POST /api/pumps` — Add a pump to a station _(checkPumpLimit enforces plan limit)
 * `GET /api/pumps/:id` — Get pump details
 * `PATCH /api/pumps/:id` — Update pump
 * `DELETE /api/pumps/:id` — Remove pump
 * `GET /api/pumps/station/:stationId` — Pumps for a station
-* `POST /api/nozzles` — Add a nozzle to a pump
+* `POST /api/nozzles` — Add a nozzle to a pump _(checkNozzleLimit enforces plan limit)
 * `GET /api/nozzles/:id` — Get nozzle details
 * `PATCH /api/nozzles/:id` — Update nozzle
 * `GET /api/nozzles/pump/:pumpId` — Nozzles for a pump

--- a/docs/CHANGELOG_AI.md
+++ b/docs/CHANGELOG_AI.md
@@ -65,3 +65,5 @@ You may now begin.
 ## 2025-06-28
 - Documented `fuel_deliveries.received_by` and `fuel_price_history.created_by` relationships in DATABASE_GUIDE.
 - Verified ERD diagram reflects these links.
+## 2025-06-29
+- Added notes in API docs that `checkPumpLimit` and `checkNozzleLimit` enforce plan limits for pump and nozzle creation routes.


### PR DESCRIPTION
## Summary
- clarify that pump creation enforces `checkPumpLimit`
- clarify that nozzle creation enforces `checkNozzleLimit`
- log these doc updates in CHANGELOG_AI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855225b80ec8320b5a68a95bc4afb09