### PR TITLE
Disable tenant owner trigger during seed

### DIFF
--- a/backend/db/seed.ts
+++ b/backend/db/seed.ts
@@ -26,6 +26,10 @@ async function seedDatabase() {
   
   try {
     console.log('🌱 Starting database seeding...');
+
+    // Disable trigger to allow tenant creation without owner
+    await client.query('ALTER TABLE tenants DISABLE TRIGGER check_tenant_owner_trigger');
+    console.log('🚧 Disabled check_tenant_owner_trigger');
     
     // 1. Create admin user
     const adminId = uuidv4();
@@ -71,6 +75,10 @@ async function seedDatabase() {
     }
     
     console.log('✅ Tenant users created');
+
+    // Re-enable trigger after users are inserted
+    await client.query('ALTER TABLE tenants ENABLE TRIGGER check_tenant_owner_trigger');
+    console.log('✅ Re-enabled check_tenant_owner_trigger');
     
     // 4. Create stations
     const stationId = uuidv4();


### PR DESCRIPTION
## Summary
- disable `check_tenant_owner_trigger` before creating tenants in seed script
- re-enable the trigger after creating tenant users
- log when trigger is disabled and re-enabled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68553b2fa5bc832098c6b2380d6a96cf