### PR TITLE
Add db reset and doc updates

### DIFF
--- a/DATABASE_SETUP.md
+++ b/DATABASE_SETUP.md
@@ -35,13 +35,13 @@ This will display your connection parameters and test the connection.
 
 ### 4. Run Database Setup
 
-Once the connection is working, run the setup script:
+Once the connection is working, run the reset command for a clean slate:
 
 ```bash
-npm run db:setup
+npm run db reset
 ```
 
-This will create the schema and seed the database with initial data.
+This command cleans the database before seeding to avoid duplicate key errors such as `admin_users_email_key`.
 
 ## Troubleshooting Connection Issues
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ npm install
 cd backend && npm install
 cd ../frontend && npm install
 cd ../backend
-npm run db:setup
+npm run db reset
 cd ..
 npm run dev
 ```
+
+Running `npm run db reset` cleans the database before seeding. This prevents duplicate key errors like `admin_users_email_key` when starting over.
 
 ### Option 2: Docker Database
 
@@ -42,9 +44,11 @@ docker run --name fuelsync-db -p 5432:5432 \
 
 # Set environment variables and setup
 export DB_HOST=localhost DB_PORT=5432 DB_NAME=fuelsync_dev DB_USER=postgres DB_PASSWORD=postgres DB_SSL=false
-npm run db:setup
+npm run db reset
 npm run dev
 ```
+
+`npm run db reset` ensures the container starts with a clean database so seeding works without duplicate key conflicts.
 
 ## 🌐 Access URLs
 
@@ -73,7 +77,8 @@ npm run build            # Build for production
 
 ### Database Management
 ```bash
-npm run db:setup         # Complete database setup with seed data
+npm run db reset         # Clean DB then seed
+npm run db:setup         # Setup without cleaning
 npm run db:check         # Test database connection
 npm run db:fix           # Fix user-station relationships
 npm run db:verify        # Verify database setup
@@ -152,14 +157,16 @@ fuelsync-hub/
 
 3. **Permission denied errors**
    ```bash
-   cd backend && npm run db:setup
+   cd backend && npm run db reset
    ```
+   Cleaning the database helps prevent duplicate key errors like `admin_users_email_key`.
 
 4. **Clean slate needed**
    ```bash
    # Reset everything
-   cd backend && npm run db:setup
+   cd backend && npm run db reset
    ```
+   This drops and recreates the database before seeding.
 
 ### Debug Tools
 - Visit http://localhost:3000/debug for debugging tools

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,7 +8,7 @@
     "dev": "ts-node-dev --respawn --transpile-only src/server.ts",
     "build": "tsc",
     "db:setup": "ts-node db/setup-db.ts && ts-node db/seed.ts && ts-node db/fix-relationships.ts",
-    "db:reset": "ts-node db/setup-db.ts && ts-node db/seed.ts && ts-node db/fix-relationships.ts",
+    "db:reset": "ts-node db/scripts/clean_db.ts && ts-node db/setup-db.ts && ts-node db/seed.ts && ts-node db/fix-relationships.ts",
     "db:check": "ts-node db/check-connection.ts",
     "db:fix": "ts-node db/fix-relationships.ts",
     "db:verify": "ts-node db/verify-seed.ts",


### PR DESCRIPTION
## Summary
- clean DB before resetting to avoid duplicates
- describe `db reset` command in README and DATABASE_SETUP
- show how `db reset` prevents admin_users_email_key errors

## Testing
- `npm test` *(fails: Database connection error because remote host unreachable, but tests pass overall)*
- `npm run lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_68553d14125083209ded8b06fc2a1390