### PR TITLE
Rename allowedRoles prop

### DIFF
--- a/frontend/src/components/auth/README.md
+++ b/frontend/src/components/auth/README.md
@@ -17,12 +17,12 @@ import ProtectedRoute from '@/components/auth/ProtectedRoute';
 </ProtectedRoute>
 
 // With role requirements - only allows users with specific roles
-<ProtectedRoute requiredRoles={['owner', 'manager']}>
+<ProtectedRoute allowedRoles={['owner', 'manager']}>
   <YourComponent />
 </ProtectedRoute>
 
 // For admin routes
-<ProtectedRoute requiredRoles={['superadmin']} isAdminRoute={true}>
+<ProtectedRoute allowedRoles={['superadmin']} isAdminRoute={true}>
   <YourComponent />
 </ProtectedRoute>
 ```
@@ -44,9 +44,9 @@ import AuthenticatedDashboardLayout from '@/components/layout/AuthenticatedDashb
 
 export default function YourPage() {
   return (
-    <AuthenticatedDashboardLayout 
-      title="Your Page Title" 
-      requiredRoles={['owner', 'manager']}
+    <AuthenticatedDashboardLayout
+      title="Your Page Title"
+      allowedRoles={['owner', 'manager']}
     >
       {/* Your page content */}
     </AuthenticatedDashboardLayout>
@@ -61,10 +61,10 @@ import AuthenticatedAdminLayout from '@/components/layout/AuthenticatedAdminLayo
 
 export default function YourAdminPage() {
   return (
-    <AuthenticatedAdminLayout 
+    <AuthenticatedAdminLayout
       title="Your Admin Page Title"
       // Default role is 'superadmin', but you can override it
-      requiredRoles={['superadmin']} 
+      allowedRoles={['superadmin']}
     >
       {/* Your admin page content */}
     </AuthenticatedAdminLayout>

--- a/frontend/src/components/layout/AuthenticatedAdminLayout.tsx
+++ b/frontend/src/components/layout/AuthenticatedAdminLayout.tsx
@@ -3,7 +3,7 @@ import AdminLayout, { AdminLayoutProps } from './AdminLayout';
 import ProtectedRoute from '../auth/ProtectedRoute';
 
 interface AuthenticatedAdminLayoutProps extends AdminLayoutProps {
-  requiredRoles?: string[];
+  allowedRoles?: string[];
   children: React.ReactNode;
 }
 
@@ -11,12 +11,12 @@ interface AuthenticatedAdminLayoutProps extends AdminLayoutProps {
  * A wrapper around AdminLayout that includes authentication protection
  */
 export default function AuthenticatedAdminLayout({
-  requiredRoles = ['superadmin'],
+  allowedRoles = ['superadmin'],
   children,
   ...props
 }: AuthenticatedAdminLayoutProps) {
   return (
-    <ProtectedRoute requiredRoles={requiredRoles} isAdminRoute={true}>
+    <ProtectedRoute allowedRoles={allowedRoles} isAdminRoute={true}>
       <AdminLayout {...props}>
         {children}
       </AdminLayout>

--- a/frontend/src/components/layout/AuthenticatedDashboardLayout.tsx
+++ b/frontend/src/components/layout/AuthenticatedDashboardLayout.tsx
@@ -3,7 +3,7 @@ import DashboardLayout, { DashboardLayoutProps } from './DashboardLayout';
 import ProtectedRoute from '../auth/ProtectedRoute';
 
 interface AuthenticatedDashboardLayoutProps extends DashboardLayoutProps {
-  requiredRoles?: string[];
+  allowedRoles?: string[];
   children: React.ReactNode;
 }
 
@@ -11,12 +11,12 @@ interface AuthenticatedDashboardLayoutProps extends DashboardLayoutProps {
  * A wrapper around DashboardLayout that includes authentication protection
  */
 export default function AuthenticatedDashboardLayout({
-  requiredRoles,
+  allowedRoles,
   children,
   ...props
 }: AuthenticatedDashboardLayoutProps) {
   return (
-    <ProtectedRoute requiredRoles={requiredRoles}>
+    <ProtectedRoute allowedRoles={allowedRoles}>
       <DashboardLayout {...props}>
         {children}
       </DashboardLayout>


### PR DESCRIPTION
## Summary
- rename prop `requiredRoles` to `allowedRoles` in Authenticated layout components
- update README examples

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685592982f5483209456634986639f30