### PR TITLE
Add API fetch helper for frontend

### DIFF
--- a/frontend/src/pages/admin/dashboard.tsx
+++ b/frontend/src/pages/admin/dashboard.tsx
@@ -18,6 +18,7 @@ import {
 } from '@mui/material';
 import { Business, SupervisorAccount, Storage } from '@mui/icons-material';
 import AdminLayout from '../../components/layout/AdminLayout';
+import { apiFetch } from '../../services/api';
 
 export default function AdminDashboard() {
   const router = useRouter();
@@ -42,7 +43,7 @@ export default function AdminDashboard() {
         }
 
         // Fetch admin info
-        const adminResponse = await fetch('http://localhost:3001/api/admin-auth/me', {
+        const adminResponse = await apiFetch('/admin-auth/me', {
           headers: {
             'Authorization': `Bearer ${token}`
           }
@@ -59,7 +60,7 @@ export default function AdminDashboard() {
         setAdmin(adminData.data);
 
         // Fetch dashboard stats
-        const statsResponse = await fetch('http://localhost:3001/api/superadmin/stats', {
+        const statsResponse = await apiFetch('/superadmin/stats', {
           headers: {
             'Authorization': `Bearer ${token}`
           }
@@ -77,7 +78,7 @@ export default function AdminDashboard() {
 
         // If stats endpoint fails, fetch tenants to get count
         else {
-          const tenantsResponse = await fetch('http://localhost:3001/api/superadmin/tenants', {
+          const tenantsResponse = await apiFetch('/superadmin/tenants', {
             headers: {
               'Authorization': `Bearer ${token}`
             }

--- a/frontend/src/pages/admin/login.tsx
+++ b/frontend/src/pages/admin/login.tsx
@@ -12,6 +12,7 @@ import {
   CircularProgress
 } from '@mui/material';
 import { LockOutlined } from '@mui/icons-material';
+import { apiFetch } from '../../services/api';
 
 export default function AdminLogin() {
   const router = useRouter();
@@ -29,7 +30,7 @@ export default function AdminLogin() {
       console.log('Attempting admin login with:', { email });
       
       // Use the admin auth endpoint
-      const response = await fetch('http://localhost:3001/api/admin-auth/login', {
+      const response = await apiFetch('/admin-auth/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/pages/admin/tenants/index.tsx
+++ b/frontend/src/pages/admin/tenants/index.tsx
@@ -25,6 +25,7 @@ import {
 } from '@mui/material';
 import { Add, Edit, Delete } from '@mui/icons-material';
 import AdminLayout from '../../../components/layout/AdminLayout';
+import { apiFetch } from '../../../services/api';
 
 export default function AdminTenants() {
   const router = useRouter();
@@ -48,7 +49,7 @@ export default function AdminTenants() {
         return;
       }
 
-      const response = await fetch('http://localhost:3001/api/superadmin/tenants', {
+      const response = await apiFetch('/superadmin/tenants', {
         headers: {
           'Authorization': `Bearer ${token}`
         }
@@ -114,12 +115,12 @@ export default function AdminTenants() {
       }
 
       const url = currentTenant
-        ? `http://localhost:3001/api/superadmin/tenants/${currentTenant.id}`
-        : 'http://localhost:3001/api/superadmin/tenants';
+        ? `/superadmin/tenants/${currentTenant.id}`
+        : '/superadmin/tenants';
 
       const method = currentTenant ? 'PATCH' : 'POST';
 
-      const response = await fetch(url, {
+      const response = await apiFetch(url, {
         method,
         headers: {
           'Authorization': `Bearer ${token}`,
@@ -152,7 +153,7 @@ export default function AdminTenants() {
         return;
       }
 
-      const response = await fetch(`http://localhost:3001/api/superadmin/tenants/${id}`, {
+      const response = await apiFetch(`/superadmin/tenants/${id}`, {
         method: 'DELETE',
         headers: {
           'Authorization': `Bearer ${token}`

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -12,6 +12,7 @@ import {
 import DashboardLayout from '../../components/layout/DashboardLayout';
 import ProtectedRoute from '../../components/auth/ProtectedRoute';
 import { getUserRole, getToken, authHeader } from '../../utils/authHelper';
+import { apiFetch } from '../../services/api';
 import { useRouter } from 'next/router';
 
 const Dashboard = () => {
@@ -40,8 +41,8 @@ const Dashboard = () => {
         
         console.log('Using headers:', headers);
         
-        const response = await fetch('http://localhost:3001/api/dashboard', {
-          headers
+        const response = await apiFetch('/dashboard', {
+          headers,
         });
         
         const data = await response.json();

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -12,6 +12,7 @@ import {
   CircularProgress
 } from '@mui/material';
 import { storeToken, parseToken, isAuthenticated } from '../utils/authHelper';
+import { apiFetch } from '../services/api';
 
 const LoginPage = () => {
   const [email, setEmail] = useState('');
@@ -36,7 +37,7 @@ const LoginPage = () => {
     try {
       console.log('Attempting login with:', { email });
       
-      const response = await fetch('http://localhost:3001/api/auth/login', {
+      const response = await apiFetch('/auth/login', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/frontend/src/pages/sales/index.tsx
+++ b/frontend/src/pages/sales/index.tsx
@@ -21,6 +21,7 @@ import DashboardLayout from '../../components/layout/DashboardLayout';
 import ProtectedRoute from '../../components/auth/ProtectedRoute';
 import { useRouter } from 'next/router';
 import { authHeader } from '../../utils/authHelper';
+import { apiFetch } from '../../services/api';
 
 const SalesPage = () => {
   const [sales, setSales] = useState([]);
@@ -44,8 +45,8 @@ const SalesPage = () => {
         
         console.log('Using headers:', headers);
         
-        const response = await fetch('http://localhost:3001/api/sales', {
-          headers
+        const response = await apiFetch('/sales', {
+          headers,
         });
         
         const data = await response.json();

--- a/frontend/src/pages/sales/new/index.tsx
+++ b/frontend/src/pages/sales/new/index.tsx
@@ -20,6 +20,7 @@ import { Save as SaveIcon, ArrowBack as ArrowBackIcon } from '@mui/icons-materia
 import DashboardLayout from '../../../components/layout/DashboardLayout';
 import ProtectedRoute from '../../../components/auth/ProtectedRoute';
 import { authHeader } from '../../../utils/authHelper';
+import { apiFetch } from '../../../services/api';
 
 const NewSalePage = () => {
   const router = useRouter();
@@ -53,8 +54,8 @@ const NewSalePage = () => {
           return;
         }
         
-        const response = await fetch('http://localhost:3001/api/stations', {
-          headers
+        const response = await apiFetch('/stations', {
+          headers,
         });
         
         if (!response.ok) {
@@ -98,8 +99,8 @@ const NewSalePage = () => {
   const fetchPumps = async (stationId) => {
     try {
       const headers = authHeader();
-      const response = await fetch(`http://localhost:3001/api/stations/${stationId}/pumps`, {
-        headers
+      const response = await apiFetch(`/stations/${stationId}/pumps`, {
+        headers,
       });
       
       if (!response.ok) {
@@ -138,8 +139,8 @@ const NewSalePage = () => {
   const fetchNozzles = async (pumpId) => {
     try {
       const headers = authHeader();
-      const response = await fetch(`http://localhost:3001/api/pumps/${pumpId}/nozzles`, {
-        headers
+      const response = await apiFetch(`/pumps/${pumpId}/nozzles`, {
+        headers,
       });
       
       if (!response.ok) {
@@ -220,7 +221,7 @@ const NewSalePage = () => {
         fuel_price: parseFloat(sale.fuel_price)
       };
       
-      const response = await fetch('http://localhost:3001/api/sales', {
+      const response = await apiFetch('/sales', {
         method: 'POST',
         headers: {
           ...headers,

--- a/frontend/src/pages/stations/[id]/edit/index.tsx
+++ b/frontend/src/pages/stations/[id]/edit/index.tsx
@@ -18,6 +18,7 @@ import { Save as SaveIcon, ArrowBack as ArrowBackIcon } from '@mui/icons-materia
 import DashboardLayout from '../../../../components/layout/DashboardLayout';
 import ProtectedRoute from '../../../../components/auth/ProtectedRoute';
 import { authHeader } from '../../../../utils/authHelper';
+import { apiFetch } from '../../../../services/api';
 
 const StationEditPage = () => {
   const router = useRouter();
@@ -52,8 +53,8 @@ const StationEditPage = () => {
           return;
         }
         
-        const response = await fetch(`http://localhost:3001/api/stations/${id}`, {
-          headers
+        const response = await apiFetch(`/stations/${id}`, {
+          headers,
         });
         
         if (!response.ok) {
@@ -113,7 +114,7 @@ const StationEditPage = () => {
         return;
       }
       
-      const response = await fetch(`http://localhost:3001/api/stations/${id}`, {
+      const response = await apiFetch(`/stations/${id}`, {
         method: 'PUT',
         headers: {
           ...headers,

--- a/frontend/src/pages/stations/[id]/index.tsx
+++ b/frontend/src/pages/stations/[id]/index.tsx
@@ -28,6 +28,7 @@ import {
 import DashboardLayout from '../../../components/layout/DashboardLayout';
 import ProtectedRoute from '../../../components/auth/ProtectedRoute';
 import { authHeader } from '../../../utils/authHelper';
+import { apiFetch } from '../../../services/api';
 
 // TabPanel component for tab content
 function TabPanel(props) {
@@ -76,8 +77,8 @@ const StationDetailPage = () => {
         }
         
         // Fetch station details
-        const stationResponse = await fetch(`http://localhost:3001/api/stations/${id}`, {
-          headers
+        const stationResponse = await apiFetch(`/stations/${id}`, {
+          headers,
         });
         
         if (!stationResponse.ok) {
@@ -96,8 +97,8 @@ const StationDetailPage = () => {
           setStation(stationData.data || stationData);
           
           // Fetch pumps for this station
-          const pumpsResponse = await fetch(`http://localhost:3001/api/stations/${id}/pumps`, {
-            headers
+          const pumpsResponse = await apiFetch(`/stations/${id}/pumps`, {
+            headers,
           });
           
           if (pumpsResponse.ok) {
@@ -145,9 +146,9 @@ const StationDetailPage = () => {
     
     try {
       const headers = authHeader();
-      const response = await fetch(`http://localhost:3001/api/stations/${id}`, {
+      const response = await apiFetch(`/stations/${id}`, {
         method: 'DELETE',
-        headers
+        headers,
       });
       
       if (response.ok) {

--- a/frontend/src/pages/stations/index.tsx
+++ b/frontend/src/pages/stations/index.tsx
@@ -15,6 +15,7 @@ import DashboardLayout from '../../components/layout/DashboardLayout';
 import ProtectedRoute from '../../components/auth/ProtectedRoute';
 import { useRouter } from 'next/router';
 import { authHeader } from '../../utils/authHelper';
+import { apiFetch } from '../../services/api';
 
 const StationsPage = () => {
   const [stations, setStations] = useState([]);
@@ -38,8 +39,8 @@ const StationsPage = () => {
         
         console.log('Using headers:', headers);
         
-        const response = await fetch('http://localhost:3001/api/stations', {
-          headers
+        const response = await apiFetch('/stations', {
+          headers,
         });
         
         const data = await response.json();

--- a/frontend/src/pages/stations/new/index.tsx
+++ b/frontend/src/pages/stations/new/index.tsx
@@ -18,6 +18,7 @@ import { Save as SaveIcon, ArrowBack as ArrowBackIcon } from '@mui/icons-materia
 import DashboardLayout from '../../../components/layout/DashboardLayout';
 import ProtectedRoute from '../../../components/auth/ProtectedRoute';
 import { authHeader } from '../../../utils/authHelper';
+import { apiFetch } from '../../../services/api';
 
 const NewStationPage = () => {
   const router = useRouter();
@@ -62,7 +63,7 @@ const NewStationPage = () => {
         return;
       }
       
-      const response = await fetch('http://localhost:3001/api/stations', {
+      const response = await apiFetch('/stations', {
         method: 'POST',
         headers: {
           ...headers,

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,0 +1,6 @@
+export const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:3001/api';
+
+export function apiFetch(path: string, options: RequestInit = {}): Promise<Response> {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  return fetch(`${API_URL}${normalizedPath}`, options);
+}


### PR DESCRIPTION
## Summary
- centralize API base URL in frontend
- replace hard-coded API fetches with helper
- ensure `NEXT_PUBLIC_API_URL` is in Next.js config

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685593d57d2883209c62cb0a726f8e71