### PR TITLE
Convert StationSelector to TypeScript

### DIFF
--- a/frontend/src/pages/debug.tsx
+++ b/frontend/src/pages/debug.tsx
@@ -18,6 +18,7 @@ import {
   ListItemText
 } from '@mui/material';
 import StationSelector from '../components/common/StationSelector';
+import type { SelectChangeEvent } from '@mui/material/Select';
 
 const DebugPage = () => {
   const [token, setToken] = useState('');
@@ -65,8 +66,8 @@ const DebugPage = () => {
     }
   };
 
-  const handleStationChange = (event) => {
-    setSelectedStation(event.target.value);
+  const handleStationChange = (event: SelectChangeEvent<string>) => {
+    setSelectedStation(event.target.value as string);
   };
 
   const parseJwt = (token) => {


### PR DESCRIPTION
## Summary
- migrate `StationSelector.jsx` to `StationSelector.tsx`
- add prop and state interfaces
- replace implicit `any` types with explicit definitions
- update Debug page for typed `StationSelector`

## Testing
- `npm run lint` *(fails: react/no-unescaped-entities errors)*

------
https://chatgpt.com/codex/tasks/task_e_6855a8cf67c88320a55b622f13f6e52f