### PR TITLE
Remove unused TS next config

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -54,7 +54,7 @@ fuelsync-hub/
 │   │   │   └── 📄 errorHandler.ts        # Error Handling
 │   │   └── 📁 styles/                    # CSS Styles
 │   ├── 📄 package.json                   # ✅ CLEANED (No Ant Design)
-│   └── 📄 next.config.js                 # Next.js Config
+│   └── 📄 next.config.js                 # Next.js Config (single config file)
 │
 ├── 📁 scripts/                           # ✅ NEW Utility Scripts
 │   ├── 📄 db.ts                          # Unified Database Management

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ fuelsync-hub/
 │   └── package.json    # Backend dependencies
 ├── frontend/           # Next.js React app
 │   ├── src/            # Source code
+│   ├── next.config.js  # Next.js configuration
 │   └── package.json    # Frontend dependencies
 └── package.json       # Root workspace configuration
 ```

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,0 @@
-import type { NextConfig } from "next";
-
-const nextConfig: NextConfig = {
-  /* config options here */
-};
-
-export default nextConfig;

--- a/planning/frontend setup
+++ b/planning/frontend setup
@@ -21,6 +21,6 @@
 │   ├── styles/               # CSS styles
 │   └── utils/                # Utility functions
 ├── package.json
-└── next.config.js
+└── next.config.js  # Next.js Config (single file)
 
 


### PR DESCRIPTION
## Summary
- delete `next.config.ts`
- document that `next.config.js` is the single Next.js config file

## Testing
- `npm run build` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6855ae07723c832084e39ce968851889