### PR TITLE
Guard debug route in production

### DIFF
--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -34,7 +34,9 @@ function AppContent({ Component, pageProps }: AppProps) {
     // Check authentication on route change
     const handleRouteChange = (url: string) => {
       // Skip auth check for public pages
-      const publicRoutes = ['/login', '/debug', '/admin/login'];
+      const publicRoutes = process.env.NODE_ENV === 'production'
+        ? ['/login', '/admin/login']
+        : ['/login', '/debug', '/admin/login'];
       if (publicRoutes.includes(url)) {
         return;
       }

--- a/frontend/src/pages/debug.tsx
+++ b/frontend/src/pages/debug.tsx
@@ -20,7 +20,8 @@ import {
 import StationSelector from '../components/common/StationSelector';
 import type { SelectChangeEvent } from '@mui/material/Select';
 
-const DebugPage = () => {
+// Only load debug tools in non-production environments
+const DebugPageContent = () => {
   const [token, setToken] = useState('');
   const [apiResponse, setApiResponse] = useState(null);
   const [apiError, setApiError] = useState(null);
@@ -215,6 +216,13 @@ const DebugPage = () => {
       
     </Container>
   );
+};
+
+const DebugPage = () => {
+  if (process.env.NODE_ENV === 'production') {
+    return null;
+  }
+  return <DebugPageContent />;
 };
 
 export default DebugPage;


### PR DESCRIPTION
## Summary
- protect the debug page from loading in production
- hide `/debug` route when `NODE_ENV` is production

## Testing
- `npm test` in `backend`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6855bb77fb6c8320a59b05d878fb55f3