### PR TITLE
Standardize controller error responses

### DIFF
--- a/backend/src/controllers/analytics.controller.ts
+++ b/backend/src/controllers/analytics.controller.ts
@@ -1,6 +1,7 @@
 // backend/src/controllers/analytics.controller.ts
 import { Request, Response } from 'express';
 import pool from '../config/database';
+import { sendErrorResponse } from '../utils/errorResponse';
 
 // Tenant sales analytics (for owner dashboard)
 export const getTenantSalesAnalytics = async (req: Request, res: Response) => {
@@ -22,7 +23,7 @@ export const getTenantSalesAnalytics = async (req: Request, res: Response) => {
     });
   } catch (err) {
     console.error('Sales analytics error:', err);
-    res.status(500).json({ message: 'Failed to fetch sales analytics.' });
+    sendErrorResponse(res, 'SERVER_ERROR', 'Failed to fetch sales analytics.', 500);
   }
 };
 
@@ -42,6 +43,6 @@ export const getGlobalAnalytics = async (_req: Request, res: Response) => {
     });
   } catch (err) {
     console.error('Global analytics error:', err);
-    res.status(500).json({ message: 'Failed to fetch global analytics.' });
+    sendErrorResponse(res, 'SERVER_ERROR', 'Failed to fetch global analytics.', 500);
   }
 };

--- a/backend/src/controllers/plan.controller.ts
+++ b/backend/src/controllers/plan.controller.ts
@@ -2,6 +2,7 @@
 import { Request, Response } from 'express';
 import pool from '../config/database';
 import { PLAN_CONFIG, PlanType, PlanConfig } from '../config/planConfig';
+import { sendErrorResponse } from '../utils/errorResponse';
 
 // Get all plans (for SuperAdmin UI)
 export const getAllPlans = (_req: Request, res: Response) => {
@@ -20,7 +21,7 @@ export const getTenantPlan = async (req: Request, res: Response) => {
     const planType = result.rows.length ? result.rows[0].subscription_plan : 'basic';
     res.json(PLAN_CONFIG[planType as PlanType]);
   } catch (err) {
-    res.status(500).json({ message: 'Failed to fetch tenant plan.' });
+    sendErrorResponse(res, 'SERVER_ERROR', 'Failed to fetch tenant plan.', 500);
   }
 };
 
@@ -32,7 +33,7 @@ export const setCustomPlan = async (req: Request, res: Response) => {
     await pool.query('UPDATE tenants SET custom_plan = $1 WHERE id = $2', [customPlan, tenantId]);
     res.json({ message: 'Custom plan set successfully.' });
   } catch (err) {
-    res.status(500).json({ message: 'Failed to set custom plan.' });
+    sendErrorResponse(res, 'SERVER_ERROR', 'Failed to set custom plan.', 500);
   }
 };
 
@@ -43,6 +44,6 @@ export const removeCustomPlan = async (req: Request, res: Response) => {
     await pool.query('UPDATE tenants SET custom_plan = NULL WHERE id = $1', [tenantId]);
     res.json({ message: 'Custom plan removed.' });
   } catch (err) {
-    res.status(500).json({ message: 'Failed to remove custom plan.' });
+    sendErrorResponse(res, 'SERVER_ERROR', 'Failed to remove custom plan.', 500);
   }
 };

--- a/backend/src/controllers/report.controller.ts
+++ b/backend/src/controllers/report.controller.ts
@@ -1,5 +1,6 @@
 import { Request, Response } from 'express';
 import * as reportService from '../services/report.service';
+import { sendErrorResponse } from '../utils/errorResponse';
 
 export const getSalesSummary = async (req: Request, res: Response) => {
   try {
@@ -7,13 +8,17 @@ export const getSalesSummary = async (req: Request, res: Response) => {
     
     // Validate required fields
     if (!stationId || !startDate || !endDate) {
-      return res.status(400).json({ message: 'Station ID, start date, and end date are required' });
+      return sendErrorResponse(
+        res,
+        'MISSING_REQUIRED_FIELDS',
+        'Station ID, start date, and end date are required'
+      );
     }
     
     // Get schema name from middleware
     const schemaName = req.schemaName;
     if (!schemaName) {
-      return res.status(500).json({ message: 'Tenant context not set' });
+      return sendErrorResponse(res, 'TENANT_CONTEXT_MISSING', 'Tenant context not set', 500);
     }
     
     const summary = await reportService.getSalesSummary(
@@ -26,7 +31,12 @@ export const getSalesSummary = async (req: Request, res: Response) => {
     return res.status(200).json(summary);
   } catch (error: any) {
     console.error('Get sales summary error:', error);
-    return res.status(500).json({ message: error.message || 'Failed to get sales summary' });
+    return sendErrorResponse(
+      res,
+      'SERVER_ERROR',
+      error.message || 'Failed to get sales summary',
+      500
+    );
   }
 };
 
@@ -36,13 +46,17 @@ export const getSalesDetail = async (req: Request, res: Response) => {
     
     // Validate required fields
     if (!stationId || !startDate || !endDate) {
-      return res.status(400).json({ message: 'Station ID, start date, and end date are required' });
+      return sendErrorResponse(
+        res,
+        'MISSING_REQUIRED_FIELDS',
+        'Station ID, start date, and end date are required'
+      );
     }
     
     // Get schema name from middleware
     const schemaName = req.schemaName;
     if (!schemaName) {
-      return res.status(500).json({ message: 'Tenant context not set' });
+      return sendErrorResponse(res, 'TENANT_CONTEXT_MISSING', 'Tenant context not set', 500);
     }
     
     const salesDetails = await reportService.getSalesDetail(
@@ -55,7 +69,7 @@ export const getSalesDetail = async (req: Request, res: Response) => {
     return res.status(200).json(salesDetails);
   } catch (error: any) {
     console.error('Get sales detail error:', error);
-    return res.status(500).json({ message: error.message || 'Failed to get sales detail' });
+    return sendErrorResponse(res, 'SERVER_ERROR', error.message || 'Failed to get sales detail', 500);
   }
 };
 
@@ -66,7 +80,7 @@ export const getCreditorsReport = async (req: Request, res: Response) => {
     // Get schema name from middleware
     const schemaName = req.schemaName;
     if (!schemaName) {
-      return res.status(500).json({ message: 'Tenant context not set' });
+      return sendErrorResponse(res, 'TENANT_CONTEXT_MISSING', 'Tenant context not set', 500);
     }
     
     const creditors = await reportService.getCreditorsReport(
@@ -77,7 +91,7 @@ export const getCreditorsReport = async (req: Request, res: Response) => {
     return res.status(200).json(creditors);
   } catch (error: any) {
     console.error('Get creditors report error:', error);
-    return res.status(500).json({ message: error.message || 'Failed to get creditors report' });
+    return sendErrorResponse(res, 'SERVER_ERROR', error.message || 'Failed to get creditors report', 500);
   }
 };
 
@@ -87,13 +101,13 @@ export const getStationPerformance = async (req: Request, res: Response) => {
     
     // Validate required fields
     if (!startDate || !endDate) {
-      return res.status(400).json({ message: 'Start date and end date are required' });
+      return sendErrorResponse(res, 'MISSING_REQUIRED_FIELDS', 'Start date and end date are required');
     }
     
     // Get schema name from middleware
     const schemaName = req.schemaName;
     if (!schemaName) {
-      return res.status(500).json({ message: 'Tenant context not set' });
+      return sendErrorResponse(res, 'TENANT_CONTEXT_MISSING', 'Tenant context not set', 500);
     }
     
     const performance = await reportService.getStationPerformance(
@@ -105,6 +119,6 @@ export const getStationPerformance = async (req: Request, res: Response) => {
     return res.status(200).json(performance);
   } catch (error: any) {
     console.error('Get station performance error:', error);
-    return res.status(500).json({ message: error.message || 'Failed to get station performance' });
+    return sendErrorResponse(res, 'SERVER_ERROR', error.message || 'Failed to get station performance', 500);
   }
 };

--- a/backend/src/controllers/tenant.controller.ts
+++ b/backend/src/controllers/tenant.controller.ts
@@ -1,17 +1,18 @@
 import { Request, Response } from 'express';
 import * as tenantService from '../services/tenant.service';
+import { sendErrorResponse } from '../utils/errorResponse';
 
 export const createTenant = async (req: Request, res: Response) => {
   try {
     const { name, email, password, subscriptionPlan } = req.body;
 
     if (!name || !email || !password || !subscriptionPlan) {
-      return res.status(400).json({ message: 'All fields are required' });
+      return sendErrorResponse(res, 'MISSING_REQUIRED_FIELDS', 'All fields are required');
     }
 
     // Validate plan type
     if (!['basic', 'premium', 'enterprise'].includes(subscriptionPlan)) {
-      return res.status(400).json({ message: 'Invalid plan type' });
+      return sendErrorResponse(res, 'INVALID_PLAN', 'Invalid plan type');
     }
 
     // Create tenant and owner user
@@ -33,7 +34,7 @@ export const createTenant = async (req: Request, res: Response) => {
     });
   } catch (error: any) {
     console.error('Tenant creation error:', error);
-    return res.status(500).json({ message: error.message || 'Failed to create tenant' });
+    return sendErrorResponse(res, 'SERVER_ERROR', error.message || 'Failed to create tenant', 500);
   }
 };
 
@@ -41,13 +42,13 @@ export const getTenants = async (req: Request, res: Response) => {
   try {
     // Check if user is admin
     if (!req.user.isAdmin) {
-      return res.status(403).json({ message: 'Unauthorized access' });
+      return sendErrorResponse(res, 'UNAUTHORIZED', 'Unauthorized access', 403);
     }
     
     const tenants = await tenantService.getAllTenants();
     return res.status(200).json(tenants);
   } catch (error: any) {
     console.error('Get tenants error:', error);
-    return res.status(500).json({ message: error.message || 'Failed to get tenants' });
+    return sendErrorResponse(res, 'SERVER_ERROR', error.message || 'Failed to get tenants', 500);
   }
 };

--- a/backend/src/utils/errorResponse.ts
+++ b/backend/src/utils/errorResponse.ts
@@ -1,0 +1,14 @@
+import { Response } from 'express';
+
+export function sendErrorResponse(
+  res: Response,
+  code: string,
+  message: string,
+  statusCode = 400
+) {
+  return res.status(statusCode).json({
+    status: 'error',
+    code,
+    message
+  });
+}


### PR DESCRIPTION
## Summary
- add `sendErrorResponse` helper
- use helper across controllers for unified API errors

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_6856b26bc280832087deb4077f981799