### PR TITLE
Add Jest test scaffolding

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,24 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  moduleFileExtensions: ['ts', 'js', 'tsx'],
+  transform: {
+    '^.+\\.(ts|tsx)$': 'ts-jest',
+  },
+  globals: {
+    'ts-jest': {
+      diagnostics: false,
+    },
+  },
+  testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)'],
+  collectCoverageFrom: ['<rootDir>/backend/src/**/*.ts'],
+  coverageDirectory: 'coverage',
+  setupFiles: ['<rootDir>/tests/env.ts'],
+  setupFilesAfterEnv: ['<rootDir>/tests/setup.ts'],
+  testTimeout: 30000,
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.4.0",
     "@types/jest": "^29.5.14",
-    "@playwright/test": "^1.42.1"
+    "@playwright/test": "^1.42.1",
+    "pg-mem": "^3.0.5",
+    "supertest": "^7.1.1"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/tests/e2e/basic.e2e.test.ts
+++ b/tests/e2e/basic.e2e.test.ts
@@ -1,0 +1,9 @@
+import request from 'supertest';
+import app from '../../backend/src/app';
+
+describe('E2E: unknown route', () => {
+  it('returns 404 for unknown path', async () => {
+    const res = await request(app).get('/unknown');
+    expect(res.status).toBe(404);
+  });
+});

--- a/tests/env.ts
+++ b/tests/env.ts
@@ -1,0 +1,2 @@
+process.env.NODE_ENV = 'test';
+process.env.USE_PG_MEM = 'true';

--- a/tests/global.d.ts
+++ b/tests/global.d.ts
@@ -1,0 +1,1 @@
+declare module 'pg-mem';

--- a/tests/integration/auth.integration.test.ts
+++ b/tests/integration/auth.integration.test.ts
@@ -1,0 +1,9 @@
+import request from 'supertest';
+import app from '../../backend/src/app';
+
+describe('POST /api/auth/login', () => {
+  it('returns 400 when missing credentials', async () => {
+    const res = await request(app).post('/api/auth/login').send({});
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/integration/db.service.test.ts
+++ b/tests/integration/db.service.test.ts
@@ -1,0 +1,25 @@
+import { newDb } from 'pg-mem';
+
+const mem = newDb();
+mem.public.none(`CREATE TABLE test_items (id uuid PRIMARY KEY, name text not null);`);
+const { Pool: MemPool } = mem.adapters.createPg();
+const pool = new MemPool();
+
+jest.mock('../../backend/src/config/database', () => ({
+  __esModule: true,
+  default: pool,
+}));
+
+import { insertWithUUID } from '../../backend/src/services/db.service';
+
+afterAll(async () => {
+  await pool.end();
+});
+
+describe('insertWithUUID', () => {
+  it('inserts a record and returns it', async () => {
+    const row = await insertWithUUID(null, 'test_items', { name: 'Alpha' }, '*');
+    const result = await pool.query('SELECT name FROM test_items WHERE id = $1', [row.id]);
+    expect(result.rows[0].name).toBe('Alpha');
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,30 @@
+import { newDb } from 'pg-mem';
+
+export const db = newDb();
+const { Pool: MemPool } = db.adapters.createPg();
+export const pool = new MemPool();
+
+beforeAll(async () => {
+  process.env.NODE_ENV = 'test';
+  process.env.USE_PG_MEM = 'true';
+  db.public.none(`
+    CREATE TABLE IF NOT EXISTS admin_users (
+      id uuid PRIMARY KEY,
+      email text not null,
+      password_hash text not null,
+      role text not null,
+      first_name text,
+      last_name text
+    );
+  `);
+});
+
+beforeEach(async () => {
+  await pool.query('DELETE FROM admin_users');
+  await pool.query(`INSERT INTO admin_users (id, email, password_hash, role, first_name, last_name)
+                   VALUES ('11111111-1111-1111-1111-111111111111', 'admin@fuelsync.com', 'hash', 'superadmin', 'Admin', 'User')`);
+});
+
+afterAll(async () => {
+  await pool.end();
+});

--- a/tests/unit/uuid.test.ts
+++ b/tests/unit/uuid.test.ts
@@ -1,0 +1,14 @@
+import { generateUUID } from '../../backend/src/utils/uuid';
+
+describe('generateUUID', () => {
+  it('returns a valid uuid', () => {
+    const id = generateUUID();
+    expect(id).toMatch(/[0-9a-fA-F-]{36}/);
+  });
+
+  it('generates unique ids', () => {
+    const first = generateUUID();
+    const second = generateUUID();
+    expect(first).not.toBe(second);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": [
+      "node",
+      "jest"
+    ],
+    "resolveJsonModule": true
+  },
+  "include": [
+    "tests/**/*",
+    "backend/src/**/*"
+  ]
+}


### PR DESCRIPTION
## Summary
- configure Jest using `jest.config.ts`
- add base tsconfig for tests
- seed in-memory PG using pg-mem in `tests/setup.ts`
- create unit, integration and e2e test examples
- add helper env setup and typings
- add pg-mem and supertest dev deps

## Testing
- `npx jest --config jest.config.ts --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6856b4d1d454832094143808bbae4425